### PR TITLE
Add main section in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "name": "David Mignot",
     "url": "http://idflood.com"
   },
+  "main": "./dist/draggable-number.js",
   "repository": {
     "type": "git",
     "url": "http://github.com/idflood/draggable-number.js"


### PR DESCRIPTION
When using this module from a CommonJS module, it would be useful if package.json has a main section. By adding it, I can easily require this module like `var DraggableNumber = require('draggable-number.js');`.